### PR TITLE
Shorten Potion duration so it display better

### DIFF
--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/player/BingoPlayer.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/player/BingoPlayer.java
@@ -152,15 +152,16 @@ public class BingoPlayer implements BingoParticipant
 
         Message.log("Giving effects to " + player.getDisplayName(), session.worldName);
 
+        final int potionDuration = 1728000; // 24 Hours
         BingoReloaded.scheduleTask(task -> {
             if (effects.contains(EffectOptionFlags.NIGHT_VISION))
-                player.addPotionEffect(new PotionEffect(PotionEffectType.NIGHT_VISION, Integer.MAX_VALUE, 1, false, false));
+                player.addPotionEffect(new PotionEffect(PotionEffectType.NIGHT_VISION, potionDuration, 1, false, false));
             if (effects.contains(EffectOptionFlags.WATER_BREATHING))
-                player.addPotionEffect(new PotionEffect(PotionEffectType.WATER_BREATHING, Integer.MAX_VALUE, 1, false, false));
+                player.addPotionEffect(new PotionEffect(PotionEffectType.WATER_BREATHING, potionDuration, 1, false, false));
             if (effects.contains(EffectOptionFlags.FIRE_RESISTANCE))
-                player.addPotionEffect(new PotionEffect(PotionEffectType.FIRE_RESISTANCE, Integer.MAX_VALUE, 1, false, false));
+                player.addPotionEffect(new PotionEffect(PotionEffectType.FIRE_RESISTANCE, potionDuration, 1, false, false));
             if (effects.contains(EffectOptionFlags.SPEED))
-                player.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, Integer.MAX_VALUE, 1, false, false));
+                player.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, potionDuration, 1, false, false));
             player.addPotionEffect(new PotionEffect(PotionEffectType.SATURATION, 2, 100, false, false));
             player.addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, 2, 100, false, false));
             player.addPotionEffect(new PotionEffect(PotionEffectType.DAMAGE_RESISTANCE, BingoReloaded.ONE_SECOND * gracePeriod, 100, false, false));

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/player/BingoPlayer.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/player/BingoPlayer.java
@@ -42,6 +42,8 @@ public class BingoPlayer implements BingoParticipant
     private final String displayName;
     private final ItemCooldownManager itemCooldowns;
 
+    private final int POTION_DURATION = 1728000; // 24 Hours
+
     public BingoPlayer(Player player, BingoTeam team, BingoSession session)
     {
         this.playerId = player.getUniqueId();
@@ -152,16 +154,15 @@ public class BingoPlayer implements BingoParticipant
 
         Message.log("Giving effects to " + player.getDisplayName(), session.worldName);
 
-        final int potionDuration = 1728000; // 24 Hours
         BingoReloaded.scheduleTask(task -> {
             if (effects.contains(EffectOptionFlags.NIGHT_VISION))
-                player.addPotionEffect(new PotionEffect(PotionEffectType.NIGHT_VISION, potionDuration, 1, false, false));
+                player.addPotionEffect(new PotionEffect(PotionEffectType.NIGHT_VISION, POTION_DURATION, 1, false, false));
             if (effects.contains(EffectOptionFlags.WATER_BREATHING))
-                player.addPotionEffect(new PotionEffect(PotionEffectType.WATER_BREATHING, potionDuration, 1, false, false));
+                player.addPotionEffect(new PotionEffect(PotionEffectType.WATER_BREATHING, POTION_DURATION, 1, false, false));
             if (effects.contains(EffectOptionFlags.FIRE_RESISTANCE))
-                player.addPotionEffect(new PotionEffect(PotionEffectType.FIRE_RESISTANCE, potionDuration, 1, false, false));
+                player.addPotionEffect(new PotionEffect(PotionEffectType.FIRE_RESISTANCE, POTION_DURATION, 1, false, false));
             if (effects.contains(EffectOptionFlags.SPEED))
-                player.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, potionDuration, 1, false, false));
+                player.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, POTION_DURATION, 1, false, false));
             player.addPotionEffect(new PotionEffect(PotionEffectType.SATURATION, 2, 100, false, false));
             player.addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, 2, 100, false, false));
             player.addPotionEffect(new PotionEffect(PotionEffectType.DAMAGE_RESISTANCE, BingoReloaded.ONE_SECOND * gracePeriod, 100, false, false));


### PR DESCRIPTION
When I was testing all my changes, the formatting for the max length of the potions was a bit jarring since there were so many numbers so I thought it might look a little better to make it 24 hours which is still more time than should ever be needed but fits cleaner on the inventory screen

Old
<img width="480" alt="image" src="https://github.com/Steaf23/BingoReloaded/assets/19912368/9c172d8e-ffef-401d-a7af-9d9d0273bbd8">
New
<img width="480" alt="image" src="https://github.com/Steaf23/BingoReloaded/assets/19912368/a8714891-6672-47ef-8729-6536d2d16837">

#12 
