### PR TITLE
Resume bingo game even after server restart/crash

### DIFF
--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/BingoReloaded.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/BingoReloaded.java
@@ -6,6 +6,11 @@ import io.github.steaf23.bingoreloaded.command.TeamChatCommand;
 import io.github.steaf23.bingoreloaded.data.*;
 import io.github.steaf23.bingoreloaded.data.BingoTranslation;
 import io.github.steaf23.bingoreloaded.data.helper.SerializablePlayer;
+import io.github.steaf23.bingoreloaded.data.recoverydata.SerializableRecoveryData;
+import io.github.steaf23.bingoreloaded.data.recoverydata.SerializableStatisticProgress;
+import io.github.steaf23.bingoreloaded.data.recoverydata.bingocard.*;
+import io.github.steaf23.bingoreloaded.data.recoverydata.timer.SerializableCountdownTimer;
+import io.github.steaf23.bingoreloaded.data.recoverydata.timer.SerializableCounterTimer;
 import io.github.steaf23.bingoreloaded.gameloop.BingoGameManager;
 import io.github.steaf23.bingoreloaded.gameloop.BingoSession;
 import io.github.steaf23.bingoreloaded.gameloop.multiple.MultiAutoBingoCommand;
@@ -67,6 +72,15 @@ public class BingoReloaded extends JavaPlugin
         ConfigurationSerialization.registerClass(CustomKit.class);
         ConfigurationSerialization.registerClass(MenuItem.class);
         ConfigurationSerialization.registerClass(SerializablePlayer.class);
+        ConfigurationSerialization.registerClass(SerializableBasicBingoCard.class);
+        ConfigurationSerialization.registerClass(SerializableBingoTask.class);
+        ConfigurationSerialization.registerClass(SerializableCardSize.class);
+        ConfigurationSerialization.registerClass(SerializableCompleteBingoCard.class);
+        ConfigurationSerialization.registerClass(SerializableLockoutBingoCard.class);
+        ConfigurationSerialization.registerClass(SerializableCounterTimer.class);
+        ConfigurationSerialization.registerClass(SerializableCountdownTimer.class);
+        ConfigurationSerialization.registerClass(SerializableRecoveryData.class);
+        ConfigurationSerialization.registerClass(SerializableStatisticProgress.class);
 
         this.config = new ConfigData(getConfig());
 

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/cards/BingoCard.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/cards/BingoCard.java
@@ -46,6 +46,14 @@ public class BingoCard
                 BingoTranslation.INFO_REGULAR_DESC.translate().split("\\n"));
     }
 
+    public BingoCard(CardSize size, List<BingoTask> tasks) {
+        this.size = size;
+        this.tasks = tasks;
+        this.menu = new CardMenu(size, BingoTranslation.CARD_TITLE.translate());
+        menu.setInfo(BingoTranslation.INFO_REGULAR_NAME.translate(),
+                BingoTranslation.INFO_REGULAR_DESC.translate().split("\\n"));
+    }
+
     /**
      * Generating a bingo card has a few steps:
      *  - Create task shuffler

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/cards/CompleteBingoCard.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/cards/CompleteBingoCard.java
@@ -16,6 +16,12 @@ public class CompleteBingoCard extends BingoCard
                 BingoTranslation.INFO_COMPLETE_DESC.translate().split("\\n"));
     }
 
+    public CompleteBingoCard(CardSize size, List<BingoTask> tasks) {
+        super(size, tasks);
+        menu.setInfo(BingoTranslation.INFO_COMPLETE_NAME.translate(),
+                BingoTranslation.INFO_COMPLETE_DESC.translate().split("\\n"));
+    }
+
     @Override
     public boolean hasBingo(BingoTeam team)
     {

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/cards/LockoutBingoCard.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/cards/LockoutBingoCard.java
@@ -8,6 +8,8 @@ import io.github.steaf23.bingoreloaded.player.TeamManager;
 import io.github.steaf23.bingoreloaded.tasks.BingoTask;
 import io.github.steaf23.bingoreloaded.util.TranslatedMessage;
 
+import java.util.List;
+
 public class LockoutBingoCard extends BingoCard
 {
     public int teamCount;
@@ -19,6 +21,14 @@ public class LockoutBingoCard extends BingoCard
         this.currentMaxTasks = size.fullCardSize;
         this.teamCount = teamCount;
 
+        menu.setInfo(BingoTranslation.INFO_LOCKOUT_NAME.translate(),
+                BingoTranslation.INFO_LOCKOUT_DESC.translate().split("\\n"));
+    }
+
+    public LockoutBingoCard(CardSize size, List<BingoTask> tasks, int teamCount, int currentMaxTasks) {
+        super(size, tasks);
+        this.teamCount = teamCount;
+        this.currentMaxTasks = currentMaxTasks;
         menu.setInfo(BingoTranslation.INFO_LOCKOUT_NAME.translate(),
                 BingoTranslation.INFO_LOCKOUT_DESC.translate().split("\\n"));
     }

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/command/BingoCommand.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/command/BingoCommand.java
@@ -83,6 +83,14 @@ public class BingoCommand implements CommandExecutor
                     return true;
                 }
             }
+            case "resume" ->
+            {
+                if (player.hasPermission("bingo.settings"))
+                {
+                    session.resumeGame();
+                    return true;
+                }
+            }
             case "end" ->
             {
                 if (player.hasPermission("bingo.settings"))

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/command/BingoTabCompleter.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/command/BingoTabCompleter.java
@@ -1,5 +1,6 @@
 package io.github.steaf23.bingoreloaded.command;
 
+import io.github.steaf23.bingoreloaded.data.recoverydata.RecoveryDataManager;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
@@ -8,6 +9,7 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class BingoTabCompleter implements TabCompleter
@@ -21,7 +23,11 @@ public class BingoTabCompleter implements TabCompleter
             switch (args.length)
             {
                 case 1 -> {
-                    return List.of("join", "getcard", "back", "leave", "stats", "end", "kit", "creator", "deathmatch");
+                    ArrayList<String> commands = new ArrayList<>(List.of("join", "getcard", "back", "leave", "stats", "end", "kit", "creator", "deathmatch"));
+                    if (new RecoveryDataManager().hasRecoveryData()) {
+                        commands.add("resume");
+                    }
+                    return commands.stream().filter(option -> option.startsWith(args[0])).toList();
                 }
                 case 2 -> {
                     switch (args[0])

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/helper/SerializablePlayer.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/helper/SerializablePlayer.java
@@ -1,22 +1,16 @@
 package io.github.steaf23.bingoreloaded.data.helper;
 
-import com.google.common.util.concurrent.ClosingFuture;
-import io.github.steaf23.bingoreloaded.BingoReloaded;
-import io.github.steaf23.bingoreloaded.util.Message;
+import io.github.steaf23.bingoreloaded.player.TeamManager;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
 import org.bukkit.configuration.serialization.SerializableAs;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
-import java.util.function.BinaryOperator;
 
 @SerializableAs("Player")
 public class SerializablePlayer implements ConfigurationSerializable
@@ -33,6 +27,7 @@ public class SerializablePlayer implements ConfigurationSerializable
     public float xpPoints;
     public ItemStack[] inventory;
     public ItemStack[] enderInventory;
+    public String teamName;
 
     public static SerializablePlayer fromPlayer(JavaPlugin plugin, Player player)
     {
@@ -48,6 +43,13 @@ public class SerializablePlayer implements ConfigurationSerializable
         data.xpPoints = player.getExp();
         data.inventory = player.getInventory().getContents();
         data.enderInventory = player.getEnderChest().getContents();
+        return data;
+    }
+
+    public static SerializablePlayer fromPlayerAndTeam(JavaPlugin plugin, Player player, String teamName)
+    {
+        SerializablePlayer data = fromPlayer(plugin, player);
+        data.teamName = teamName;
         return data;
     }
 
@@ -77,6 +79,17 @@ public class SerializablePlayer implements ConfigurationSerializable
         player.updateInventory();
     }
 
+    public void toPlayerAndTeam(Player player, TeamManager teamManager)
+    {
+        if (!playerId.equals(player.getUniqueId()))
+            return;
+        toPlayer(player);
+
+        if (teamName != null) {
+            teamManager.addPlayerToTeam(player, teamName);
+        }
+    }
+
     @NotNull
     @Override
     public Map<String, Object> serialize()
@@ -94,6 +107,7 @@ public class SerializablePlayer implements ConfigurationSerializable
         data.put("xp_points", xpPoints);
         data.put("inventory", inventory);
         data.put("ender_inventory", enderInventory);
+        data.put("team_name", teamName);
 
         return data;
     }
@@ -112,6 +126,7 @@ public class SerializablePlayer implements ConfigurationSerializable
         player.xpPoints = ((Double)(data.getOrDefault("xp_points", 0.0f))).floatValue();
         player.inventory = ((ArrayList<ItemStack>)data.getOrDefault("inventory", null)).toArray(new ItemStack[]{});
         player.enderInventory = ((ArrayList<ItemStack>)data.getOrDefault("ender_inventory", null)).toArray(new ItemStack[]{});
+        player.teamName = (String) data.getOrDefault("team_name", null);
 
         return player;
     }

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/RecoveryData.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/RecoveryData.java
@@ -1,0 +1,40 @@
+package io.github.steaf23.bingoreloaded.data.recoverydata;
+
+import io.github.steaf23.bingoreloaded.cards.BingoCard;
+import io.github.steaf23.bingoreloaded.settings.BingoSettings;
+import io.github.steaf23.bingoreloaded.tasks.statistics.StatisticTracker;
+import io.github.steaf23.bingoreloaded.util.timer.GameTimer;
+
+public class RecoveryData {
+    private BingoCard bingoCard;
+    private GameTimer timer;
+    private BingoSettings settings;
+    private StatisticTracker statisticTracker;
+
+    public RecoveryData(BingoCard bingoCard, GameTimer timer, BingoSettings settings, StatisticTracker statisticTracker) {
+        this.bingoCard = bingoCard;
+        this.timer = timer;
+        this.settings = settings;
+        this.statisticTracker = statisticTracker;
+    }
+
+    public BingoCard getBingoCard() {
+        return bingoCard;
+    }
+
+    public GameTimer getTimer() {
+        return timer;
+    }
+
+    public BingoSettings getSettings() {
+        return settings;
+    }
+
+    public StatisticTracker getStatisticTracker() {
+        return statisticTracker;
+    }
+
+    public boolean hasNull() {
+        return bingoCard == null || timer == null || settings == null;
+    }
+}

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/RecoveryDataManager.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/RecoveryDataManager.java
@@ -3,10 +3,14 @@ package io.github.steaf23.bingoreloaded.data.recoverydata;
 import io.github.steaf23.bingoreloaded.BingoReloaded;
 import io.github.steaf23.bingoreloaded.cards.BingoCard;
 import io.github.steaf23.bingoreloaded.data.YmlDataManager;
+import io.github.steaf23.bingoreloaded.data.helper.SerializablePlayer;
+import io.github.steaf23.bingoreloaded.data.recoverydata.bingocard.SerializableBasicBingoCard;
 import io.github.steaf23.bingoreloaded.gameloop.BingoSession;
 import io.github.steaf23.bingoreloaded.settings.BingoSettings;
 import io.github.steaf23.bingoreloaded.tasks.statistics.StatisticTracker;
+import io.github.steaf23.bingoreloaded.util.Message;
 import io.github.steaf23.bingoreloaded.util.timer.GameTimer;
+import org.bukkit.entity.Player;
 
 public class RecoveryDataManager {
     private final YmlDataManager data = BingoReloaded.createYmlDataManager("recovery.yml");
@@ -17,9 +21,21 @@ public class RecoveryDataManager {
         data.saveConfig();
     }
 
+    public void savePlayerRecoveryData(Player player)
+    {
+        if (player != null) {
+            data.getConfig().set(player.getUniqueId().toString(), SerializablePlayer.fromPlayer(BingoReloaded.getPlugin(BingoReloaded.class), player));
+            data.saveConfig();
+        }
+    }
+
     public void clearRecoveryData() {
         data.getConfig().set("recovery_data", null);
         data.saveConfig();
+    }
+
+    public boolean hasRecoveryData() {
+        return data.getConfig().contains("recovery_data");
     }
 
     /**
@@ -36,5 +52,23 @@ public class RecoveryDataManager {
         data.getConfig().set("recovery_data", null);
         data.saveConfig();
         return serializableRecoveryData.toRecoveryData(session);
+    }
+
+    public Player loadPlayerRecoveryData(Player player)
+    {
+        if (player == null) {
+            Message.error("Cannot recover data for null Player");
+            return null;
+        }
+        if (!data.getConfig().contains(player.getUniqueId().toString()))
+        {
+            Message.error("Could not find " + player.getDisplayName() + "'s data!");
+            return null;
+        }
+
+        data.getConfig().getSerializable(player.getUniqueId().toString(), SerializablePlayer.class).toPlayer(player);
+        data.getConfig().set(player.getUniqueId().toString(), null);
+        data.saveConfig();
+        return player;
     }
 }

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/RecoveryDataManager.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/RecoveryDataManager.java
@@ -4,8 +4,8 @@ import io.github.steaf23.bingoreloaded.BingoReloaded;
 import io.github.steaf23.bingoreloaded.cards.BingoCard;
 import io.github.steaf23.bingoreloaded.data.YmlDataManager;
 import io.github.steaf23.bingoreloaded.data.helper.SerializablePlayer;
-import io.github.steaf23.bingoreloaded.data.recoverydata.bingocard.SerializableBasicBingoCard;
 import io.github.steaf23.bingoreloaded.gameloop.BingoSession;
+import io.github.steaf23.bingoreloaded.player.TeamManager;
 import io.github.steaf23.bingoreloaded.settings.BingoSettings;
 import io.github.steaf23.bingoreloaded.tasks.statistics.StatisticTracker;
 import io.github.steaf23.bingoreloaded.util.Message;
@@ -21,10 +21,10 @@ public class RecoveryDataManager {
         data.saveConfig();
     }
 
-    public void savePlayerRecoveryData(Player player)
+    public void savePlayerRecoveryData(Player player, String teamName)
     {
         if (player != null) {
-            data.getConfig().set(player.getUniqueId().toString(), SerializablePlayer.fromPlayer(BingoReloaded.getPlugin(BingoReloaded.class), player));
+            data.getConfig().set(player.getUniqueId().toString(), SerializablePlayer.fromPlayerAndTeam(BingoReloaded.getPlugin(BingoReloaded.class), player, teamName));
             data.saveConfig();
         }
     }
@@ -54,21 +54,18 @@ public class RecoveryDataManager {
         return serializableRecoveryData.toRecoveryData(session);
     }
 
-    public Player loadPlayerRecoveryData(Player player)
+    public void loadPlayerRecoveryData(Player player, TeamManager teamManager)
     {
-        if (player == null) {
-            Message.error("Cannot recover data for null Player");
-            return null;
+        if (player == null || teamManager == null) {
+            return;
         }
         if (!data.getConfig().contains(player.getUniqueId().toString()))
         {
             Message.error("Could not find " + player.getDisplayName() + "'s data!");
-            return null;
+            return;
         }
-
-        data.getConfig().getSerializable(player.getUniqueId().toString(), SerializablePlayer.class).toPlayer(player);
+        data.getConfig().getSerializable(player.getUniqueId().toString(), SerializablePlayer.class).toPlayerAndTeam(player, teamManager);
         data.getConfig().set(player.getUniqueId().toString(), null);
         data.saveConfig();
-        return player;
     }
 }

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/RecoveryDataManager.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/RecoveryDataManager.java
@@ -1,0 +1,40 @@
+package io.github.steaf23.bingoreloaded.data.recoverydata;
+
+import io.github.steaf23.bingoreloaded.BingoReloaded;
+import io.github.steaf23.bingoreloaded.cards.BingoCard;
+import io.github.steaf23.bingoreloaded.data.YmlDataManager;
+import io.github.steaf23.bingoreloaded.gameloop.BingoSession;
+import io.github.steaf23.bingoreloaded.settings.BingoSettings;
+import io.github.steaf23.bingoreloaded.tasks.statistics.StatisticTracker;
+import io.github.steaf23.bingoreloaded.util.timer.GameTimer;
+
+public class RecoveryDataManager {
+    private final YmlDataManager data = BingoReloaded.createYmlDataManager("recovery.yml");
+
+    public void saveRecoveryData(BingoCard bingoCard, GameTimer timer, BingoSettings settings, StatisticTracker statisticTracker)
+    {
+        data.getConfig().set("recovery_data", new SerializableRecoveryData(bingoCard, timer, settings, statisticTracker));
+        data.saveConfig();
+    }
+
+    public void clearRecoveryData() {
+        data.getConfig().set("recovery_data", null);
+        data.saveConfig();
+    }
+
+    /**
+     * Loads recovery information from recovery.yml of the game ongoing prior to server shutting down
+     * @param session
+     * @return the saved recovery data
+     */
+    public RecoveryData loadRecoveryData(BingoSession session)
+    {
+        SerializableRecoveryData serializableRecoveryData = data.getConfig().getSerializable("recovery_data", SerializableRecoveryData.class);
+        if (serializableRecoveryData == null) {
+            return null;
+        }
+        data.getConfig().set("recovery_data", null);
+        data.saveConfig();
+        return serializableRecoveryData.toRecoveryData(session);
+    }
+}

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/SerializableRecoveryData.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/SerializableRecoveryData.java
@@ -1,0 +1,100 @@
+package io.github.steaf23.bingoreloaded.data.recoverydata;
+
+import io.github.steaf23.bingoreloaded.cards.BingoCard;
+import io.github.steaf23.bingoreloaded.cards.CompleteBingoCard;
+import io.github.steaf23.bingoreloaded.cards.LockoutBingoCard;
+import io.github.steaf23.bingoreloaded.data.recoverydata.bingocard.SerializableBingoCard;
+import io.github.steaf23.bingoreloaded.data.recoverydata.bingocard.SerializableCardSize;
+import io.github.steaf23.bingoreloaded.data.recoverydata.bingocard.SerializableCompleteBingoCard;
+import io.github.steaf23.bingoreloaded.data.recoverydata.bingocard.SerializableLockoutBingoCard;
+import io.github.steaf23.bingoreloaded.data.recoverydata.timer.SerializableCountdownTimer;
+import io.github.steaf23.bingoreloaded.data.recoverydata.timer.SerializableCounterTimer;
+import io.github.steaf23.bingoreloaded.data.recoverydata.timer.SerializableGameTimer;
+import io.github.steaf23.bingoreloaded.gameloop.BingoSession;
+import io.github.steaf23.bingoreloaded.settings.BingoSettings;
+import io.github.steaf23.bingoreloaded.tasks.statistics.StatisticProgress;
+import io.github.steaf23.bingoreloaded.tasks.statistics.StatisticTracker;
+import io.github.steaf23.bingoreloaded.util.timer.CountdownTimer;
+import io.github.steaf23.bingoreloaded.util.timer.CounterTimer;
+import io.github.steaf23.bingoreloaded.util.timer.GameTimer;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+import org.bukkit.configuration.serialization.SerializableAs;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+
+
+@SerializableAs("RecoveryData")
+public class SerializableRecoveryData implements ConfigurationSerializable {
+    private final SerializableBingoCard bingoCard;
+    private final String BINGO_CARD_ID = "bingo_card";
+    private final SerializableGameTimer timer;
+    private final String TIMER_ID = "game_timer";
+    private final BingoSettings settings;
+    private final String SETTINGS_ID = "settings";
+    private final SerializableStatisticProgress[] statisticProgresses;
+    private final String STATS_ID = "statistic_progresses";
+
+    public SerializableRecoveryData(BingoCard bingoCard, GameTimer timer, BingoSettings settings, StatisticTracker statisticTracker) {
+        if (bingoCard instanceof LockoutBingoCard) {
+            this.bingoCard = new SerializableLockoutBingoCard((LockoutBingoCard) bingoCard);
+        } else if (bingoCard instanceof CompleteBingoCard) {
+            this.bingoCard = new SerializableCompleteBingoCard((CompleteBingoCard) bingoCard);
+        } else {
+            this.bingoCard = new SerializableBingoCard(bingoCard);
+        }
+        if (timer instanceof CountdownTimer) {
+            this.timer = new SerializableCountdownTimer((CountdownTimer) timer);
+        } else if (timer instanceof CounterTimer) {
+            this.timer = new SerializableCounterTimer((CounterTimer) timer);
+        } else {
+            this.timer = null;
+        }
+        this.settings = settings;
+        if (statisticTracker == null) {
+            this.statisticProgresses = null;
+        } else {
+            this.statisticProgresses = statisticTracker.getStatistics()
+                    .stream()
+                    .map(SerializableStatisticProgress::new)
+                    .toList()
+                    .toArray(new SerializableStatisticProgress[0]);
+        }
+    }
+
+    public SerializableRecoveryData(Map<String, Object> data) {
+        bingoCard = (SerializableBingoCard) data.getOrDefault(BINGO_CARD_ID, null);
+        timer = (SerializableGameTimer) data.getOrDefault(TIMER_ID, null);
+        settings = (BingoSettings) data.getOrDefault(SETTINGS_ID, null);
+        statisticProgresses = (SerializableStatisticProgress[]) data.getOrDefault(STATS_ID, null);
+    }
+
+    @NotNull
+    @Override
+    public Map<String, Object> serialize() {
+        Map<String, Object> data = new HashMap<>();
+
+        data.put(BINGO_CARD_ID, bingoCard);
+        data.put(TIMER_ID, timer);
+        data.put(SETTINGS_ID, settings);
+        data.put(STATS_ID, statisticProgresses);
+
+        return data;
+    }
+
+    public RecoveryData toRecoveryData(BingoSession session) {
+        StatisticTracker tracker = null;
+        if (statisticProgresses != null) {
+            List<StatisticProgress> stats = Arrays.stream(statisticProgresses)
+                    .map(statisticProgress -> statisticProgress.toStatisticProgress(session))
+                    .toList();
+            tracker = new StatisticTracker(session.worldName, stats)
+        }
+        return new RecoveryData(
+                bingoCard.toBingoCard(session),
+                timer.toGameTimer(session),
+                settings,
+                tracker
+        );
+    }
+}

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/SerializableRecoveryData.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/SerializableRecoveryData.java
@@ -4,7 +4,6 @@ import io.github.steaf23.bingoreloaded.cards.BingoCard;
 import io.github.steaf23.bingoreloaded.cards.CompleteBingoCard;
 import io.github.steaf23.bingoreloaded.cards.LockoutBingoCard;
 import io.github.steaf23.bingoreloaded.data.recoverydata.bingocard.SerializableBingoCard;
-import io.github.steaf23.bingoreloaded.data.recoverydata.bingocard.SerializableCardSize;
 import io.github.steaf23.bingoreloaded.data.recoverydata.bingocard.SerializableCompleteBingoCard;
 import io.github.steaf23.bingoreloaded.data.recoverydata.bingocard.SerializableLockoutBingoCard;
 import io.github.steaf23.bingoreloaded.data.recoverydata.timer.SerializableCountdownTimer;
@@ -88,7 +87,7 @@ public class SerializableRecoveryData implements ConfigurationSerializable {
             List<StatisticProgress> stats = Arrays.stream(statisticProgresses)
                     .map(statisticProgress -> statisticProgress.toStatisticProgress(session))
                     .toList();
-            tracker = new StatisticTracker(session.worldName, stats)
+            tracker = new StatisticTracker(session.worldName, stats);
         }
         return new RecoveryData(
                 bingoCard.toBingoCard(session),

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/SerializableStatisticProgress.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/SerializableStatisticProgress.java
@@ -18,28 +18,40 @@ import java.util.UUID;
 
 
 @SerializableAs("StatisticProgress")
-public class SerializableStatisticProgress implements ConfigurationSerializable {
-    private UUID player;
-    private final String PLAYER_ID = "player";
-    private BingoStatistic statistic;
-    private final String STAT_ID = "statistic";
-    private int progressLeft;
-    private final String PROGRESS_ID = "progress_left";
-    private int previousGlobalProgress;
-    private final String PREV_PROGRESS_ID = "previous_global_progress";
+public record SerializableStatisticProgress(
+        UUID player,
+        BingoStatistic statistic,
+        int progressLeft,
+        int previousGlobalProgress
+) implements ConfigurationSerializable {
+    private static final String PLAYER_ID = "player";
+    private static final String STAT_ID = "statistic";
+    private static final String PROGRESS_ID = "progress_left";
+    private static final String PREV_PROGRESS_ID = "previous_global_progress";
 
     public SerializableStatisticProgress(StatisticProgress statisticProgress) {
-        player = statisticProgress.getPlayer().getId();
-        statistic = statisticProgress.getStatistic();
-        progressLeft = statisticProgress.progressLeft;
-        previousGlobalProgress = statisticProgress.previousGlobalProgress;
+        this(
+                statisticProgress.getPlayer().getId(),
+                statisticProgress.getStatistic(),
+                statisticProgress.progressLeft,
+                statisticProgress.previousGlobalProgress
+        );
     }
 
-    public SerializableStatisticProgress(Map<String, Object> data) {
-        player = (UUID) data.getOrDefault(PLAYER_ID, null);
-        progressLeft = (Integer) data.getOrDefault(PROGRESS_ID, 0);
-        previousGlobalProgress = (Integer) data.getOrDefault(PREV_PROGRESS_ID, 0);
-        statistic = (BingoStatistic) data.getOrDefault(STAT_ID, null);
+    public static SerializableStatisticProgress deserialize(Map<String, Object> data)
+    {
+        String playerString = (String)data.getOrDefault(PLAYER_ID, null);
+        UUID player = null;
+        if (playerString != null) {
+            player = UUID.fromString(playerString);
+        }
+        return new SerializableStatisticProgress(
+                player,
+                (BingoStatistic) data.getOrDefault(STAT_ID, null),
+                (Integer) data.getOrDefault(PROGRESS_ID, 0),
+                (Integer) data.getOrDefault(PREV_PROGRESS_ID, 0)
+
+        );
     }
 
     @NotNull
@@ -47,7 +59,9 @@ public class SerializableStatisticProgress implements ConfigurationSerializable 
     public Map<String, Object> serialize() {
         Map<String, Object> data = new HashMap<>();
 
-        data.put(PLAYER_ID, player);
+        if (player != null) {
+            data.put(PLAYER_ID, player.toString());
+        }
         data.put(PROGRESS_ID, progressLeft);
         data.put(PREV_PROGRESS_ID, previousGlobalProgress);
         data.put(STAT_ID, statistic);

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/SerializableStatisticProgress.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/SerializableStatisticProgress.java
@@ -1,0 +1,67 @@
+package io.github.steaf23.bingoreloaded.data.recoverydata;
+
+import io.github.steaf23.bingoreloaded.gameloop.BingoSession;
+import io.github.steaf23.bingoreloaded.player.BingoParticipant;
+import io.github.steaf23.bingoreloaded.player.BingoPlayer;
+import io.github.steaf23.bingoreloaded.tasks.BingoTask;
+import io.github.steaf23.bingoreloaded.tasks.TaskData;
+import io.github.steaf23.bingoreloaded.tasks.statistics.BingoStatistic;
+import io.github.steaf23.bingoreloaded.tasks.statistics.StatisticProgress;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+import org.bukkit.configuration.serialization.SerializableAs;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+
+@SerializableAs("StatisticProgress")
+public class SerializableStatisticProgress implements ConfigurationSerializable {
+    private UUID player;
+    private final String PLAYER_ID = "player";
+    private BingoStatistic statistic;
+    private final String STAT_ID = "statistic";
+    private int progressLeft;
+    private final String PROGRESS_ID = "progress_left";
+    private int previousGlobalProgress;
+    private final String PREV_PROGRESS_ID = "previous_global_progress";
+
+    public SerializableStatisticProgress(StatisticProgress statisticProgress) {
+        player = statisticProgress.getPlayer().getId();
+        statistic = statisticProgress.getStatistic();
+        progressLeft = statisticProgress.progressLeft;
+        previousGlobalProgress = statisticProgress.previousGlobalProgress;
+    }
+
+    public SerializableStatisticProgress(Map<String, Object> data) {
+        player = (UUID) data.getOrDefault(PLAYER_ID, null);
+        progressLeft = (Integer) data.getOrDefault(PROGRESS_ID, 0);
+        previousGlobalProgress = (Integer) data.getOrDefault(PREV_PROGRESS_ID, 0);
+        statistic = (BingoStatistic) data.getOrDefault(STAT_ID, null);
+    }
+
+    @NotNull
+    @Override
+    public Map<String, Object> serialize() {
+        Map<String, Object> data = new HashMap<>();
+
+        data.put(PLAYER_ID, player);
+        data.put(PROGRESS_ID, progressLeft);
+        data.put(PREV_PROGRESS_ID, previousGlobalProgress);
+        data.put(STAT_ID, statistic);
+
+        return data;
+    }
+
+    public StatisticProgress toStatisticProgress(BingoSession session) {
+        if (player != null) {
+            BingoParticipant participant = session.teamManager.getBingoParticipant(player);
+            if (participant instanceof BingoPlayer) {
+                return new StatisticProgress(statistic, (BingoPlayer) participant, progressLeft, previousGlobalProgress);
+            }
+        }
+        return null;
+    }
+}

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/bingocard/SerializableBasicBingoCard.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/bingocard/SerializableBasicBingoCard.java
@@ -2,7 +2,6 @@ package io.github.steaf23.bingoreloaded.data.recoverydata.bingocard;
 
 import io.github.steaf23.bingoreloaded.cards.BingoCard;
 import io.github.steaf23.bingoreloaded.cards.CardSize;
-import io.github.steaf23.bingoreloaded.cards.CompleteBingoCard;
 import io.github.steaf23.bingoreloaded.gameloop.BingoSession;
 import io.github.steaf23.bingoreloaded.tasks.BingoTask;
 import org.bukkit.Bukkit;
@@ -17,16 +16,15 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
-import static io.github.steaf23.bingoreloaded.data.recoverydata.bingocard.SerializableBasicBingoCard.BINGO_TASKS_ID;
-import static io.github.steaf23.bingoreloaded.data.recoverydata.bingocard.SerializableBasicBingoCard.CARD_SIZE_ID;
-
-@SerializableAs("CompleteBingoCard")
-public record SerializableCompleteBingoCard(
+@SerializableAs("BasicBingoCard")
+public record SerializableBasicBingoCard(
         List<SerializableBingoTask> bingoTaskList,
         SerializableCardSize cardSize
 ) implements ConfigurationSerializable, SerializableBingoCard {
+    static final String BINGO_TASKS_ID = "bingo_tasks";
+    static final String CARD_SIZE_ID = "card_size";
 
-    public SerializableCompleteBingoCard(CompleteBingoCard bingoCard) {
+    public SerializableBasicBingoCard(BingoCard bingoCard) {
         this(
                 bingoCard.tasks
                         .stream()
@@ -36,10 +34,10 @@ public record SerializableCompleteBingoCard(
         );
     }
 
-    public static SerializableCompleteBingoCard deserialize(Map<String, Object> data)
+    public static SerializableBasicBingoCard deserialize(Map<String, Object> data)
     {
-        return new SerializableCompleteBingoCard(
-                (List<SerializableBingoTask>) data.getOrDefault(BINGO_TASKS_ID, null),
+        return new SerializableBasicBingoCard(
+                (List<SerializableBingoTask>) data.getOrDefault(BINGO_TASKS_ID, new SerializableBingoTask[0]),
                 (SerializableCardSize) data.getOrDefault(CARD_SIZE_ID, null)
         );
     }
@@ -55,12 +53,12 @@ public record SerializableCompleteBingoCard(
         return data;
     }
 
-    @Override
     public BingoCard toBingoCard(BingoSession session) {
-        List<BingoTask> tasks = bingoTaskList.stream()
+        List<BingoTask> tasks = bingoTaskList
+                .stream()
                 .map(bingoTask -> bingoTask.toBingoTask(session))
                 .toList();
         CardSize cardSize = this.cardSize.toCardSize();
-        return new CompleteBingoCard(cardSize, tasks);
+        return new BingoCard(cardSize, tasks);
     }
 }

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/bingocard/SerializableBingoCard.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/bingocard/SerializableBingoCard.java
@@ -1,0 +1,55 @@
+package io.github.steaf23.bingoreloaded.data.recoverydata.bingocard;
+
+import io.github.steaf23.bingoreloaded.cards.BingoCard;
+import io.github.steaf23.bingoreloaded.cards.CardSize;
+import io.github.steaf23.bingoreloaded.gameloop.BingoSession;
+import io.github.steaf23.bingoreloaded.tasks.BingoTask;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+import org.bukkit.configuration.serialization.SerializableAs;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@SerializableAs("BingoCard")
+public class SerializableBingoCard implements ConfigurationSerializable {
+    SerializableBingoTask[] bingoTaskList;
+    private final String BINGO_TASKS_ID = "bingo_tasks";
+    SerializableCardSize cardSize;
+    private final String CARD_SIZE_ID = "card_size";
+
+    public SerializableBingoCard(BingoCard bingoCard) {
+        this.bingoTaskList = bingoCard.tasks
+                .stream()
+                .map(SerializableBingoTask::new)
+                .toList()
+                .toArray(new SerializableBingoTask[0]);
+        this.cardSize = new SerializableCardSize(bingoCard.size);
+    }
+
+    public SerializableBingoCard(Map<String, Object> data) {
+        bingoTaskList = (SerializableBingoTask[]) data.getOrDefault(BINGO_TASKS_ID, new SerializableBingoTask[0]);
+        cardSize = (SerializableCardSize) data.getOrDefault(CARD_SIZE_ID, null);
+    }
+
+    @NotNull
+    @Override
+    public Map<String, Object> serialize() {
+        Map<String, Object> data = new HashMap<>();
+
+        data.put(BINGO_TASKS_ID, bingoTaskList);
+        data.put(CARD_SIZE_ID, cardSize);
+
+        return data;
+    }
+
+    public BingoCard toBingoCard(BingoSession session) {
+        List<BingoTask> tasks = Arrays.stream(bingoTaskList)
+                .map(bingoTask -> bingoTask.toBingoTask(session))
+                .toList();
+        CardSize cardSize = this.cardSize.toCardSize();
+        return new BingoCard(cardSize, tasks);
+    }
+}

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/bingocard/SerializableBingoCard.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/bingocard/SerializableBingoCard.java
@@ -1,55 +1,8 @@
 package io.github.steaf23.bingoreloaded.data.recoverydata.bingocard;
 
 import io.github.steaf23.bingoreloaded.cards.BingoCard;
-import io.github.steaf23.bingoreloaded.cards.CardSize;
 import io.github.steaf23.bingoreloaded.gameloop.BingoSession;
-import io.github.steaf23.bingoreloaded.tasks.BingoTask;
-import org.bukkit.configuration.serialization.ConfigurationSerializable;
-import org.bukkit.configuration.serialization.SerializableAs;
-import org.jetbrains.annotations.NotNull;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-@SerializableAs("BingoCard")
-public class SerializableBingoCard implements ConfigurationSerializable {
-    SerializableBingoTask[] bingoTaskList;
-    private final String BINGO_TASKS_ID = "bingo_tasks";
-    SerializableCardSize cardSize;
-    private final String CARD_SIZE_ID = "card_size";
-
-    public SerializableBingoCard(BingoCard bingoCard) {
-        this.bingoTaskList = bingoCard.tasks
-                .stream()
-                .map(SerializableBingoTask::new)
-                .toList()
-                .toArray(new SerializableBingoTask[0]);
-        this.cardSize = new SerializableCardSize(bingoCard.size);
-    }
-
-    public SerializableBingoCard(Map<String, Object> data) {
-        bingoTaskList = (SerializableBingoTask[]) data.getOrDefault(BINGO_TASKS_ID, new SerializableBingoTask[0]);
-        cardSize = (SerializableCardSize) data.getOrDefault(CARD_SIZE_ID, null);
-    }
-
-    @NotNull
-    @Override
-    public Map<String, Object> serialize() {
-        Map<String, Object> data = new HashMap<>();
-
-        data.put(BINGO_TASKS_ID, bingoTaskList);
-        data.put(CARD_SIZE_ID, cardSize);
-
-        return data;
-    }
-
-    public BingoCard toBingoCard(BingoSession session) {
-        List<BingoTask> tasks = Arrays.stream(bingoTaskList)
-                .map(bingoTask -> bingoTask.toBingoTask(session))
-                .toList();
-        CardSize cardSize = this.cardSize.toCardSize();
-        return new BingoCard(cardSize, tasks);
-    }
+public interface SerializableBingoCard {
+    BingoCard toBingoCard(BingoSession session);
 }

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/bingocard/SerializableBingoTask.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/bingocard/SerializableBingoTask.java
@@ -1,0 +1,67 @@
+package io.github.steaf23.bingoreloaded.data.recoverydata.bingocard;
+
+import io.github.steaf23.bingoreloaded.gameloop.BingoSession;
+import io.github.steaf23.bingoreloaded.player.BingoParticipant;
+import io.github.steaf23.bingoreloaded.tasks.BingoTask;
+import io.github.steaf23.bingoreloaded.tasks.TaskData;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+import org.bukkit.configuration.serialization.SerializableAs;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+
+@SerializableAs("BingoTask")
+public class SerializableBingoTask implements ConfigurationSerializable {
+    private UUID completedBy;
+    private final String COMPLETED_BY_ID = "completed_by";
+    private long completedAt;
+    private final String COMPLETED_AT_ID = "completed_at";
+    private boolean voided;
+    private final String VOIDED_ID = "voided";
+    private TaskData taskData;
+    private final String DATA_ID = "task_data";
+
+    public SerializableBingoTask(BingoTask task) {
+        completedBy = task.completedBy.map(BingoParticipant::getId).orElse(null);
+        completedAt = task.completedAt;
+        voided = task.isVoided();
+        taskData = task.data;
+    }
+
+    public SerializableBingoTask(Map<String, Object> data) {
+        completedBy = (UUID) data.getOrDefault(COMPLETED_BY_ID, null);
+        completedAt = (Long) data.getOrDefault(COMPLETED_AT_ID, -1L);
+        voided = (Boolean) data.getOrDefault(VOIDED_ID, false);
+        taskData = (TaskData) data.getOrDefault(DATA_ID, null);
+    }
+
+    @NotNull
+    @Override
+    public Map<String, Object> serialize() {
+        Map<String, Object> data = new HashMap<>();
+
+        data.put(COMPLETED_BY_ID, completedBy);
+        data.put(COMPLETED_AT_ID, completedAt);
+        data.put(VOIDED_ID, voided);
+        data.put(DATA_ID, taskData);
+
+        return data;
+    }
+
+    public BingoTask toBingoTask(BingoSession session) {
+        BingoTask task = new BingoTask(taskData);
+        if (completedBy != null) {
+            BingoParticipant completedParticipant = session.teamManager.getBingoParticipant(completedBy);
+            if (completedParticipant != null) {
+                task.completedBy = Optional.of(completedParticipant);
+                task.completedAt = completedAt;
+            }
+        }
+        task.setVoided(voided);
+        return task;
+    }
+}

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/bingocard/SerializableBingoTask.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/bingocard/SerializableBingoTask.java
@@ -15,28 +15,44 @@ import java.util.UUID;
 
 
 @SerializableAs("BingoTask")
-public class SerializableBingoTask implements ConfigurationSerializable {
-    private UUID completedBy;
-    private final String COMPLETED_BY_ID = "completed_by";
-    private long completedAt;
-    private final String COMPLETED_AT_ID = "completed_at";
-    private boolean voided;
-    private final String VOIDED_ID = "voided";
-    private TaskData taskData;
-    private final String DATA_ID = "task_data";
+public record SerializableBingoTask(
+        UUID completedBy,
+        int completedAt,
+        boolean voided,
+        TaskData taskData
+
+) implements ConfigurationSerializable {
+
+    private static final String COMPLETED_BY_ID = "completed_by";
+
+    private static final String COMPLETED_AT_ID = "completed_at";
+
+    private static final String VOIDED_ID = "voided";
+
+    private static final String DATA_ID = "task_data";
 
     public SerializableBingoTask(BingoTask task) {
-        completedBy = task.completedBy.map(BingoParticipant::getId).orElse(null);
-        completedAt = task.completedAt;
-        voided = task.isVoided();
-        taskData = task.data;
+        this(
+            task.completedBy.map(BingoParticipant::getId).orElse(null),
+            (int) task.completedAt,
+            task.isVoided(),
+            task.data
+        );
     }
 
-    public SerializableBingoTask(Map<String, Object> data) {
-        completedBy = (UUID) data.getOrDefault(COMPLETED_BY_ID, null);
-        completedAt = (Long) data.getOrDefault(COMPLETED_AT_ID, -1L);
-        voided = (Boolean) data.getOrDefault(VOIDED_ID, false);
-        taskData = (TaskData) data.getOrDefault(DATA_ID, null);
+    public static SerializableBingoTask deserialize(Map<String, Object> data)
+    {
+        String completedByString = (String)data.getOrDefault(COMPLETED_BY_ID, null);
+        UUID completedBy = null;
+        if (completedByString != null) {
+            completedBy = UUID.fromString(completedByString);
+        }
+        return new SerializableBingoTask(
+                completedBy,
+                (Integer) data.getOrDefault(COMPLETED_AT_ID, -1),
+                (Boolean) data.getOrDefault(VOIDED_ID, false),
+                (TaskData) data.getOrDefault(DATA_ID, null)
+        );
     }
 
     @NotNull
@@ -44,7 +60,9 @@ public class SerializableBingoTask implements ConfigurationSerializable {
     public Map<String, Object> serialize() {
         Map<String, Object> data = new HashMap<>();
 
-        data.put(COMPLETED_BY_ID, completedBy);
+        if (completedBy != null) {
+            data.put(COMPLETED_BY_ID, completedBy.toString());
+        }
         data.put(COMPLETED_AT_ID, completedAt);
         data.put(VOIDED_ID, voided);
         data.put(DATA_ID, taskData);

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/bingocard/SerializableCardSize.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/bingocard/SerializableCardSize.java
@@ -1,0 +1,37 @@
+package io.github.steaf23.bingoreloaded.data.recoverydata.bingocard;
+
+import io.github.steaf23.bingoreloaded.cards.CardSize;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+import org.bukkit.configuration.serialization.SerializableAs;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@SerializableAs("CardSize")
+public class SerializableCardSize implements ConfigurationSerializable {
+    private String name;
+    private final String NAME_ID = "name";
+
+    public SerializableCardSize(CardSize cardSize) {
+        name = cardSize.name();
+    }
+
+    public SerializableCardSize(Map<String, Object> data) {
+        name = (String) data.getOrDefault(NAME_ID, CardSize.X5.name());
+    }
+
+    @NotNull
+    @Override
+    public Map<String, Object> serialize() {
+        Map<String, Object> data = new HashMap<>();
+
+        data.put(NAME_ID, name);
+
+        return data;
+    }
+
+    public CardSize toCardSize() {
+        return CardSize.valueOf(name);
+    }
+}

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/bingocard/SerializableCardSize.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/bingocard/SerializableCardSize.java
@@ -1,24 +1,29 @@
 package io.github.steaf23.bingoreloaded.data.recoverydata.bingocard;
 
 import io.github.steaf23.bingoreloaded.cards.CardSize;
+import org.bukkit.Bukkit;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
 import org.bukkit.configuration.serialization.SerializableAs;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
 
 @SerializableAs("CardSize")
-public class SerializableCardSize implements ConfigurationSerializable {
-    private String name;
-    private final String NAME_ID = "name";
+public record SerializableCardSize(
+        String name
+) implements ConfigurationSerializable {
+    private static final String NAME_ID = "name";
 
     public SerializableCardSize(CardSize cardSize) {
-        name = cardSize.name();
+        this(cardSize.name());
     }
 
-    public SerializableCardSize(Map<String, Object> data) {
-        name = (String) data.getOrDefault(NAME_ID, CardSize.X5.name());
+    public static SerializableCardSize deserialize(Map<String, Object> data)
+    {
+        return new SerializableCardSize((String) data.getOrDefault(NAME_ID, CardSize.X5.name()));
     }
 
     @NotNull

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/bingocard/SerializableCompleteBingoCard.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/bingocard/SerializableCompleteBingoCard.java
@@ -1,0 +1,47 @@
+package io.github.steaf23.bingoreloaded.data.recoverydata.bingocard;
+
+import io.github.steaf23.bingoreloaded.cards.BingoCard;
+import io.github.steaf23.bingoreloaded.cards.CardSize;
+import io.github.steaf23.bingoreloaded.cards.CompleteBingoCard;
+import io.github.steaf23.bingoreloaded.gameloop.BingoSession;
+import io.github.steaf23.bingoreloaded.tasks.BingoTask;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+import org.bukkit.configuration.serialization.SerializableAs;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+@SerializableAs("CompleteBingoCard")
+public class SerializableCompleteBingoCard extends SerializableBingoCard implements ConfigurationSerializable {
+
+    public SerializableCompleteBingoCard(CompleteBingoCard bingoCard) {
+        super(bingoCard);
+        this.bingoTaskList = bingoCard.tasks
+                .stream()
+                .map(SerializableBingoTask::new)
+                .toList()
+                .toArray(new SerializableBingoTask[0]);
+        this.cardSize = new SerializableCardSize(bingoCard.size);
+    }
+
+    public SerializableCompleteBingoCard(Map<String, Object> data) {
+        super(data);
+    }
+
+    @NotNull
+    @Override
+    public Map<String, Object> serialize() {
+        return super.serialize();
+    }
+
+    @Override
+    public BingoCard toBingoCard(BingoSession session) {
+        List<BingoTask> tasks = Arrays.stream(bingoTaskList)
+                .map(bingoTask -> bingoTask.toBingoTask(session))
+                .toList();
+        CardSize cardSize = this.cardSize.toCardSize();
+        return new CompleteBingoCard(cardSize, tasks);
+    }
+}

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/bingocard/SerializableLockoutBingoCard.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/bingocard/SerializableLockoutBingoCard.java
@@ -1,0 +1,54 @@
+package io.github.steaf23.bingoreloaded.data.recoverydata.bingocard;
+
+import io.github.steaf23.bingoreloaded.cards.BingoCard;
+import io.github.steaf23.bingoreloaded.cards.CardSize;
+import io.github.steaf23.bingoreloaded.cards.LockoutBingoCard;
+import io.github.steaf23.bingoreloaded.gameloop.BingoSession;
+import io.github.steaf23.bingoreloaded.tasks.BingoTask;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+import org.bukkit.configuration.serialization.SerializableAs;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+@SerializableAs("LockoutBingoCard")
+public class SerializableLockoutBingoCard extends SerializableBingoCard implements ConfigurationSerializable {
+    private int teamCount;
+    private final String TEAM_COUNT_ID = "team_count";
+    private int currentMaxTasks;
+    private final String MAX_TASKS_ID = "current_max_tasks";
+
+    public SerializableLockoutBingoCard(LockoutBingoCard bingoCard) {
+        super(bingoCard);
+        teamCount = bingoCard.teamCount;
+        currentMaxTasks = bingoCard.currentMaxTasks;
+    }
+
+    public SerializableLockoutBingoCard(Map<String, Object> data) {
+        super(data);
+        teamCount = (Integer) data.getOrDefault(TEAM_COUNT_ID, 0);
+        currentMaxTasks = (Integer) data.getOrDefault(MAX_TASKS_ID, 0);
+    }
+
+    @NotNull
+    @Override
+    public Map<String, Object> serialize() {
+        Map<String, Object> data = super.serialize();
+
+        data.put(TEAM_COUNT_ID, teamCount);
+        data.put(MAX_TASKS_ID, currentMaxTasks);
+
+        return super.serialize();
+    }
+
+    @Override
+    public BingoCard toBingoCard(BingoSession session) {
+        List<BingoTask> tasks = Arrays.stream(super.bingoTaskList)
+                .map(bingoTask -> bingoTask.toBingoTask(session))
+                .toList();
+        CardSize cardSize = this.cardSize.toCardSize();
+        return new LockoutBingoCard(cardSize, tasks, teamCount, currentMaxTasks);
+    }
+}

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/timer/SerializableCountdownTimer.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/timer/SerializableCountdownTimer.java
@@ -1,45 +1,54 @@
 package io.github.steaf23.bingoreloaded.data.recoverydata.timer;
 
 import io.github.steaf23.bingoreloaded.gameloop.BingoSession;
+import io.github.steaf23.bingoreloaded.util.Message;
 import io.github.steaf23.bingoreloaded.util.timer.CountdownTimer;
 import io.github.steaf23.bingoreloaded.util.timer.GameTimer;
+import org.bukkit.Bukkit;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
 import org.bukkit.configuration.serialization.SerializableAs;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
 
 @SerializableAs("CountdownTimer")
-public class SerializableCountdownTimer extends SerializableGameTimer implements ConfigurationSerializable {
-    private int medThreshold;
-    private final String MED_ID = "med_threshold";
-    private int lowThreshold;
-    private final String LOW_ID = "low_threshold";
+public record SerializableCountdownTimer (
+        int time,
+        int medThreshold,
+        int lowThreshold
+) implements ConfigurationSerializable, SerializableGameTimer {
+    private static final String TIME_ID = "time";
+    private static final String MED_ID = "med_threshold";
+    private static final String LOW_ID = "low_threshold";
+
     public SerializableCountdownTimer(CountdownTimer countdownTimer) {
-        super(countdownTimer);
-        medThreshold = countdownTimer.medThreshold;
-        lowThreshold = countdownTimer.lowThreshold;
+        this((int) countdownTimer.getTime(), countdownTimer.medThreshold, countdownTimer.lowThreshold);
     }
 
-    public SerializableCountdownTimer(Map<String, Object> data) {
-        super(data);
-        medThreshold = (Integer) data.getOrDefault(MED_ID, 0);
-        lowThreshold = (Integer) data.getOrDefault(LOW_ID, 0);
+    public static SerializableCountdownTimer deserialize(Map<String, Object> data)
+    {
+        return new SerializableCountdownTimer(
+                (Integer) data.getOrDefault(TIME_ID, 0),
+                (Integer) data.getOrDefault(MED_ID, 0),
+                (Integer) data.getOrDefault(LOW_ID, 0)
+        );
     }
 
     @NotNull
     @Override
     public Map<String, Object> serialize() {
-        Map<String, Object> data = super.serialize();
+        Map<String, Object> data = new HashMap<>();
 
-        data.put(MED_ID, medThreshold);
+        data.put(TIME_ID, time);data.put(MED_ID, medThreshold);
         data.put(LOW_ID, lowThreshold);
 
         return data;
     }
 
-    @Override
     public GameTimer toGameTimer(BingoSession session) {
-        return new CountdownTimer(time.intValue(), medThreshold, lowThreshold, session);
+        return new CountdownTimer(time, medThreshold, lowThreshold, session);
     }
 }

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/timer/SerializableCountdownTimer.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/timer/SerializableCountdownTimer.java
@@ -1,0 +1,45 @@
+package io.github.steaf23.bingoreloaded.data.recoverydata.timer;
+
+import io.github.steaf23.bingoreloaded.gameloop.BingoSession;
+import io.github.steaf23.bingoreloaded.util.timer.CountdownTimer;
+import io.github.steaf23.bingoreloaded.util.timer.GameTimer;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+import org.bukkit.configuration.serialization.SerializableAs;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+
+@SerializableAs("CountdownTimer")
+public class SerializableCountdownTimer extends SerializableGameTimer implements ConfigurationSerializable {
+    private int medThreshold;
+    private final String MED_ID = "med_threshold";
+    private int lowThreshold;
+    private final String LOW_ID = "low_threshold";
+    public SerializableCountdownTimer(CountdownTimer countdownTimer) {
+        super(countdownTimer);
+        medThreshold = countdownTimer.medThreshold;
+        lowThreshold = countdownTimer.lowThreshold;
+    }
+
+    public SerializableCountdownTimer(Map<String, Object> data) {
+        super(data);
+        medThreshold = (Integer) data.getOrDefault(MED_ID, 0);
+        lowThreshold = (Integer) data.getOrDefault(LOW_ID, 0);
+    }
+
+    @NotNull
+    @Override
+    public Map<String, Object> serialize() {
+        Map<String, Object> data = super.serialize();
+
+        data.put(MED_ID, medThreshold);
+        data.put(LOW_ID, lowThreshold);
+
+        return data;
+    }
+
+    @Override
+    public GameTimer toGameTimer(BingoSession session) {
+        return new CountdownTimer(time.intValue(), medThreshold, lowThreshold, session);
+    }
+}

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/timer/SerializableCounterTimer.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/timer/SerializableCounterTimer.java
@@ -1,29 +1,44 @@
 package io.github.steaf23.bingoreloaded.data.recoverydata.timer;
 
+import io.github.steaf23.bingoreloaded.cards.CardSize;
+import io.github.steaf23.bingoreloaded.data.recoverydata.bingocard.SerializableCardSize;
 import io.github.steaf23.bingoreloaded.gameloop.BingoSession;
+import io.github.steaf23.bingoreloaded.util.Message;
 import io.github.steaf23.bingoreloaded.util.timer.CounterTimer;
 import io.github.steaf23.bingoreloaded.util.timer.GameTimer;
+import org.bukkit.Bukkit;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
 import org.bukkit.configuration.serialization.SerializableAs;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
 
 @SerializableAs("CounterTimer")
-public class SerializableCounterTimer extends SerializableGameTimer implements ConfigurationSerializable {
+public record SerializableCounterTimer(
+        int time
+) implements ConfigurationSerializable, SerializableGameTimer {
+    private static final String TIME_ID = "time";
 
     public SerializableCounterTimer(CounterTimer counterTimer) {
-        super(counterTimer);
+        this((int) counterTimer.getTime());
     }
 
-    public SerializableCounterTimer(Map<String, Object> data) {
-        super(data);
+    public static SerializableCounterTimer deserialize(Map<String, Object> data)
+    {
+        return new SerializableCounterTimer((Integer) data.getOrDefault(TIME_ID, 0));
     }
 
     @NotNull
     @Override
     public Map<String, Object> serialize() {
-        return super.serialize();
+        Map<String, Object> data = new HashMap<>();
+
+        data.put(TIME_ID, time);
+
+        return data;
     }
 
     @Override

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/timer/SerializableCounterTimer.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/timer/SerializableCounterTimer.java
@@ -1,0 +1,35 @@
+package io.github.steaf23.bingoreloaded.data.recoverydata.timer;
+
+import io.github.steaf23.bingoreloaded.gameloop.BingoSession;
+import io.github.steaf23.bingoreloaded.util.timer.CounterTimer;
+import io.github.steaf23.bingoreloaded.util.timer.GameTimer;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+import org.bukkit.configuration.serialization.SerializableAs;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+
+@SerializableAs("CounterTimer")
+public class SerializableCounterTimer extends SerializableGameTimer implements ConfigurationSerializable {
+
+    public SerializableCounterTimer(CounterTimer counterTimer) {
+        super(counterTimer);
+    }
+
+    public SerializableCounterTimer(Map<String, Object> data) {
+        super(data);
+    }
+
+    @NotNull
+    @Override
+    public Map<String, Object> serialize() {
+        return super.serialize();
+    }
+
+    @Override
+    public GameTimer toGameTimer(BingoSession session) {
+        CounterTimer timer = new CounterTimer();
+        timer.updateTime(time);
+        return timer;
+    }
+}

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/timer/SerializableGameTimer.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/timer/SerializableGameTimer.java
@@ -1,37 +1,22 @@
 package io.github.steaf23.bingoreloaded.data.recoverydata.timer;
 
 import io.github.steaf23.bingoreloaded.gameloop.BingoSession;
+import io.github.steaf23.bingoreloaded.util.Message;
 import io.github.steaf23.bingoreloaded.util.timer.CounterTimer;
 import io.github.steaf23.bingoreloaded.util.timer.GameTimer;
+import org.bukkit.Bukkit;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
 import org.bukkit.configuration.serialization.SerializableAs;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+
+
 
 @SerializableAs("CounterTimer")
-public abstract class SerializableGameTimer implements ConfigurationSerializable {
-    Long time;
-    private final String TIME_ID = "time";
-
-    public SerializableGameTimer(GameTimer timer) {
-        time = timer.getTime();
-    }
-
-    public SerializableGameTimer(Map<String, Object> data) {
-        time = (Long)data.getOrDefault(TIME_ID, 0.0);;
-    }
-
-    @NotNull
-    @Override
-    public Map<String, Object> serialize() {
-        Map<String, Object> data = new HashMap<>();
-
-        data.put(TIME_ID, time);
-
-        return data;
-    }
-
-    abstract public GameTimer toGameTimer(BingoSession session);
+public interface SerializableGameTimer {
+    GameTimer toGameTimer(BingoSession session);
 }

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/timer/SerializableGameTimer.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/data/recoverydata/timer/SerializableGameTimer.java
@@ -1,0 +1,37 @@
+package io.github.steaf23.bingoreloaded.data.recoverydata.timer;
+
+import io.github.steaf23.bingoreloaded.gameloop.BingoSession;
+import io.github.steaf23.bingoreloaded.util.timer.CounterTimer;
+import io.github.steaf23.bingoreloaded.util.timer.GameTimer;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+import org.bukkit.configuration.serialization.SerializableAs;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@SerializableAs("CounterTimer")
+public abstract class SerializableGameTimer implements ConfigurationSerializable {
+    Long time;
+    private final String TIME_ID = "time";
+
+    public SerializableGameTimer(GameTimer timer) {
+        time = timer.getTime();
+    }
+
+    public SerializableGameTimer(Map<String, Object> data) {
+        time = (Long)data.getOrDefault(TIME_ID, 0.0);;
+    }
+
+    @NotNull
+    @Override
+    public Map<String, Object> serialize() {
+        Map<String, Object> data = new HashMap<>();
+
+        data.put(TIME_ID, time);
+
+        return data;
+    }
+
+    abstract public GameTimer toGameTimer(BingoSession session);
+}

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/gameloop/BingoGame.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/gameloop/BingoGame.java
@@ -246,6 +246,11 @@ public class BingoGame implements GamePhase
         RecoveryDataManager recoveryDataManager = new RecoveryDataManager();
         saveTask = Bukkit.getScheduler().runTaskTimer(BingoReloaded.getPlugin(BingoReloaded.class), () -> {
             recoveryDataManager.saveRecoveryData(session.teamManager.getLeadingTeam().card, timer, settings, statTracker);
+            teamManager
+                    .getParticipants()
+                    .stream()
+                    .map(BingoParticipant::sessionPlayer)
+                    .forEach(player -> recoveryDataManager.savePlayerRecoveryData(player.orElse(null)));
         }, 30 * BingoReloaded.ONE_SECOND, 30 * BingoReloaded.ONE_SECOND);
     }
 

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/gameloop/BingoGame.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/gameloop/BingoGame.java
@@ -76,6 +76,20 @@ public class BingoGame implements GamePhase
         start();
     }
 
+    public BingoGame(BingoSession session, BingoSettings settings, ConfigData config, GameTimer timer, BingoCard masterCard, StatisticTracker statistics) {
+        this.session = session;
+        this.config = config;
+        this.worldName = session.worldName;
+        this.teamManager = session.teamManager;
+        this.scoreboard = session.scoreboard;
+        this.settings = settings;
+        this.deadPlayers = new HashMap<>();
+        this.cardEventManager = new CardEventManager(worldName);
+        this.statTracker = statistics;
+        this.timer = timer;
+        resume(masterCard);
+    }
+
     private void start()
     {
         this.hasTimerStarted = false;
@@ -84,17 +98,8 @@ public class BingoGame implements GamePhase
             timer = new CountdownTimer(settings.countdownDuration() * 60, 5 * 60, 60, session);
         else
             timer = new CounterTimer();
-        timer.setNotifier(time ->
-        {
-            Message timerMessage = timer.getTimeDisplayMessage(false);
-            for (BingoParticipant participant : getTeamManager().getParticipants())
-            {
-                var p = participant.sessionPlayer();
-                p.ifPresent(value -> Message.sendActionMessage(timerMessage, value));
-            }
-            if (statTracker != null)
-                statTracker.updateProgress();
-        });
+
+        initTimerNotifier();
 
         deathMatchTask = null;
         World world = Bukkit.getWorld(getWorldName());
@@ -108,14 +113,7 @@ public class BingoGame implements GamePhase
         // Generate cards
         BingoCard masterCard = CardBuilder.fromMode(settings.mode(), settings.size(), getTeamManager().getActiveTeams().size());
         masterCard.generateCard(settings.card(), settings.seed(), !config.disableAdvancements, !config.disableStatistics);
-        getTeamManager().initializeCards(masterCard);
-
-        Set<BingoCard> cards = new HashSet<>();
-        for (BingoTeam activeTeam : getTeamManager().getActiveTeams())
-        {
-            cards.add(activeTeam.card);
-        }
-        cardEventManager.setCards(cards.stream().toList());
+        initCards(masterCard);
 
         if (statTracker != null)
             statTracker.start(getTeamManager().getActiveTeams());
@@ -139,9 +137,64 @@ public class BingoGame implements GamePhase
         // Post-start Setup
         scoreboard.reset();
 
-        var event = new BingoStartedEvent(session);
-        Bukkit.getPluginManager().callEvent(event);
+        sendBingoStartEvent();
 
+        initBingoStartTimer();
+    }
+
+    private void resume(BingoCard masterCard)
+    {
+        this.hasTimerStarted = false;
+        initTimerNotifier();
+
+        deathMatchTask = null;
+
+        initCards(masterCard);
+
+        if (statTracker != null)
+            statTracker.start(getTeamManager().getActiveTeams());
+
+        getTeamManager().getParticipants().forEach(p ->
+        {
+            if (p.sessionPlayer().isPresent())
+            {
+                returnCardToPlayer((BingoPlayer) p);
+            }
+        });
+
+        // Post-start Setup
+        scoreboard.updateTeamScores();
+
+        sendBingoStartEvent();
+
+        initBingoStartTimer();
+    }
+
+    private void initTimerNotifier() {
+        timer.setNotifier(time ->
+        {
+            Message timerMessage = timer.getTimeDisplayMessage(false);
+            for (BingoParticipant participant : getTeamManager().getParticipants())
+            {
+                var p = participant.sessionPlayer();
+                p.ifPresent(value -> Message.sendActionMessage(timerMessage, value));
+            }
+            if (statTracker != null)
+                statTracker.updateProgress();
+        });
+    }
+
+    private void initCards(BingoCard masterCard) {
+        getTeamManager().initializeCards(masterCard);
+        Set<BingoCard> cards = new HashSet<>();
+        for (BingoTeam activeTeam : getTeamManager().getActiveTeams())
+        {
+            cards.add(activeTeam.card);
+        }
+        cardEventManager.setCards(cards.stream().toList());
+    }
+
+    private void initBingoStartTimer() {
         // Countdown before the game actually starts
         startingTimer = new CountdownTimer(10, 6, 3, session);
         startingTimer.setNotifier(time -> {
@@ -181,7 +234,12 @@ public class BingoGame implements GamePhase
         });
         BingoReloaded.scheduleTask(task -> {
             startingTimer.start();
-        }, 1 * BingoReloaded.ONE_SECOND);
+        }, BingoReloaded.ONE_SECOND);
+    }
+
+    private void sendBingoStartEvent() {
+        var event = new BingoStartedEvent(session);
+        Bukkit.getPluginManager().callEvent(event);
     }
 
     public void end(@Nullable BingoTeam winningTeam)

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/gameloop/BingoGame.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/gameloop/BingoGame.java
@@ -249,8 +249,9 @@ public class BingoGame implements GamePhase
             teamManager
                     .getParticipants()
                     .stream()
-                    .map(BingoParticipant::sessionPlayer)
-                    .forEach(player -> recoveryDataManager.savePlayerRecoveryData(player.orElse(null)));
+                    .filter(player -> player.getTeam() != null)
+                    .filter(player -> player instanceof BingoPlayer)
+                    .forEach(player -> recoveryDataManager.savePlayerRecoveryData(player.sessionPlayer().orElse(null), player.getTeam().getName()));
         }, 30 * BingoReloaded.ONE_SECOND, 30 * BingoReloaded.ONE_SECOND);
     }
 

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/gameloop/BingoSession.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/gameloop/BingoSession.java
@@ -9,7 +9,6 @@ import io.github.steaf23.bingoreloaded.data.recoverydata.RecoveryData;
 import io.github.steaf23.bingoreloaded.data.recoverydata.RecoveryDataManager;
 import io.github.steaf23.bingoreloaded.event.*;
 import io.github.steaf23.bingoreloaded.player.BingoParticipant;
-import io.github.steaf23.bingoreloaded.player.BingoPlayer;
 import io.github.steaf23.bingoreloaded.player.TeamManager;
 import io.github.steaf23.bingoreloaded.settings.BingoSettings;
 import io.github.steaf23.bingoreloaded.settings.BingoSettingsBuilder;
@@ -125,12 +124,10 @@ public class BingoSession
         if (recoveryData == null || recoveryData.hasNull()) {
             return;
         }
-        teamManager
-                .getParticipants()
-                .stream()
-                .filter(bingoParticipant -> bingoParticipant instanceof BingoPlayer)
-                .map(BingoParticipant::sessionPlayer)
-                .forEach(player -> manager.loadPlayerRecoveryData(player.orElse(null)));
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            manager.loadPlayerRecoveryData(player, teamManager);
+        }
+
         scoreboard.updateTeamScores();
         // The game is started in the constructor
         phase = new BingoGame(this, recoveryData.getSettings(), config, recoveryData.getTimer(), recoveryData.getBingoCard(), recoveryData.getStatisticTracker());

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/gameloop/BingoSession.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/gameloop/BingoSession.java
@@ -5,6 +5,8 @@ import io.github.steaf23.bingoreloaded.data.BingoCardsData;
 import io.github.steaf23.bingoreloaded.data.BingoSettingsData;
 import io.github.steaf23.bingoreloaded.data.BingoTranslation;
 import io.github.steaf23.bingoreloaded.data.ConfigData;
+import io.github.steaf23.bingoreloaded.data.recoverydata.RecoveryData;
+import io.github.steaf23.bingoreloaded.data.recoverydata.RecoveryDataManager;
 import io.github.steaf23.bingoreloaded.event.*;
 import io.github.steaf23.bingoreloaded.player.BingoParticipant;
 import io.github.steaf23.bingoreloaded.player.TeamManager;
@@ -108,6 +110,23 @@ public class BingoSession
         scoreboard.updateTeamScores();
         // The game is started in the constructor
         phase = new BingoGame(this, gameSettings == null ? settings : gameSettings.view(), config);
+    }
+
+    public void resumeGame()
+    {
+        if (isRunning())
+        {
+            return;
+        }
+
+        RecoveryData recoveryData = new RecoveryDataManager().loadRecoveryData(this);
+        if (recoveryData == null || recoveryData.hasNull()) {
+            return;
+        }
+
+        scoreboard.updateTeamScores();
+        // The game is started in the constructor
+        phase = new BingoGame(this, recoveryData.getSettings(), config, recoveryData.getTimer(), recoveryData.getBingoCard(), recoveryData.getStatisticTracker());
     }
 
     public void endGame()

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/gameloop/BingoSession.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/gameloop/BingoSession.java
@@ -9,6 +9,7 @@ import io.github.steaf23.bingoreloaded.data.recoverydata.RecoveryData;
 import io.github.steaf23.bingoreloaded.data.recoverydata.RecoveryDataManager;
 import io.github.steaf23.bingoreloaded.event.*;
 import io.github.steaf23.bingoreloaded.player.BingoParticipant;
+import io.github.steaf23.bingoreloaded.player.BingoPlayer;
 import io.github.steaf23.bingoreloaded.player.TeamManager;
 import io.github.steaf23.bingoreloaded.settings.BingoSettings;
 import io.github.steaf23.bingoreloaded.settings.BingoSettingsBuilder;
@@ -119,11 +120,17 @@ public class BingoSession
             return;
         }
 
-        RecoveryData recoveryData = new RecoveryDataManager().loadRecoveryData(this);
+        RecoveryDataManager manager = new RecoveryDataManager();
+        RecoveryData recoveryData = manager.loadRecoveryData(this);
         if (recoveryData == null || recoveryData.hasNull()) {
             return;
         }
-
+        teamManager
+                .getParticipants()
+                .stream()
+                .filter(bingoParticipant -> bingoParticipant instanceof BingoPlayer)
+                .map(BingoParticipant::sessionPlayer)
+                .forEach(player -> manager.loadPlayerRecoveryData(player.orElse(null)));
         scoreboard.updateTeamScores();
         // The game is started in the constructor
         phase = new BingoGame(this, recoveryData.getSettings(), config, recoveryData.getTimer(), recoveryData.getBingoCard(), recoveryData.getStatisticTracker());

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/player/BingoPlayer.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/player/BingoPlayer.java
@@ -27,6 +27,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.EnumSet;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.logging.Level;
 
 /**
  * This class describes a player in a single bingo session.

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/settings/SettingsPreviewBoard.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/settings/SettingsPreviewBoard.java
@@ -1,6 +1,5 @@
 package io.github.steaf23.bingoreloaded.settings;
 
-import io.github.steaf23.bingoreloaded.event.BingoParticipantLeaveEvent;
 import io.github.steaf23.bingoreloaded.event.BingoSettingsUpdatedEvent;
 import io.github.steaf23.bingoreloaded.player.BingoPlayer;
 import io.github.steaf23.bingoreloaded.settings.BingoSettings;

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/tasks/BingoTask.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/tasks/BingoTask.java
@@ -235,6 +235,14 @@ public class BingoTask
 
     public BingoTask copy()
     {
-        return new BingoTask(data);
+        BingoTask task = new BingoTask(data);
+        if (completedBy.isPresent()) {
+                task.completedBy = completedBy;
+                task.completedAt = completedAt;
+        }
+        task.setVoided(voided);
+        return task;
     }
+
+
 }

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/tasks/statistics/StatisticProgress.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/tasks/statistics/StatisticProgress.java
@@ -9,9 +9,9 @@ public class StatisticProgress
 {
     final BingoStatistic statistic;
     final BingoPlayer player;
-    int progressLeft;
+    public int progressLeft;
 
-    int previousGlobalProgress;
+    public int previousGlobalProgress;
 
     public StatisticProgress(BingoStatistic statistic, BingoPlayer player, int targetScore)
     {
@@ -26,6 +26,14 @@ public class StatisticProgress
         this.previousGlobalProgress = 0;
 
         setPlayerTotalScore(0);
+    }
+
+    public StatisticProgress(BingoStatistic statistic, BingoPlayer player, int progressLeft, int previousGlobalProgress)
+    {
+        this.statistic = statistic;
+        this.player = player;
+        this.progressLeft = progressLeft;
+        this.previousGlobalProgress = previousGlobalProgress;
     }
 
     public boolean done()
@@ -106,5 +114,13 @@ public class StatisticProgress
         {
             gamePlayer.setStatistic(statistic.stat(), value);
         }
+    }
+
+    public BingoPlayer getPlayer() {
+        return player;
+    }
+
+    public BingoStatistic getStatistic() {
+        return statistic;
     }
 }

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/tasks/statistics/StatisticTracker.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/tasks/statistics/StatisticTracker.java
@@ -23,6 +23,12 @@ public class StatisticTracker
         this.worldName = worldName;
     }
 
+    public StatisticTracker(String worldName, List<StatisticProgress> statistics)
+    {
+        this.statistics = statistics;
+        this.worldName = worldName;
+    }
+
     public void start(Set<BingoTeam> teams)
     {
         for (BingoTeam team : teams)
@@ -92,5 +98,9 @@ public class StatisticTracker
         }
 
         statistics.removeIf(progress -> progress.progressLeft <= 0);
+    }
+
+    public List<StatisticProgress> getStatistics() {
+        return statistics;
     }
 }

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/util/timer/CountdownTimer.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/util/timer/CountdownTimer.java
@@ -42,7 +42,7 @@ public class CountdownTimer extends GameTimer
     }
 
     @Override
-    protected void updateTime(long newTime)
+    public void updateTime(long newTime)
     {
         super.updateTime(newTime);
         if (getTime() <= 0)

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/util/timer/GameTimer.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/util/timer/GameTimer.java
@@ -57,7 +57,7 @@ public abstract class GameTimer
         return time;
     }
 
-    protected void updateTime(long newTime)
+    public void updateTime(long newTime)
     {
         time = newTime;
         if (notifier != null)


### PR DESCRIPTION
Not sure this is a feature you want to add or that is how you would approach it but I needed to add this for my own version of the plugin since my server crashes when too many people are flying around at once.

Tried my best to limit changes to existing code to ensure it could not break things already working. 

I have not tested it enough to be confident it handles all scenarios.

Totally ok if you don't want to merge this into your repo. I will keep it on my personal branch and continue to use it either way so all good!