### PR TITLE
Update score before ending game

### DIFF
--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/gameloop/BingoGame.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/gameloop/BingoGame.java
@@ -510,11 +510,13 @@ public class BingoGame implements GamePhase
             if (otherParticipant.sessionPlayer().isPresent())
                 otherParticipant.sessionPlayer().get().playSound(otherParticipant.sessionPlayer().get(), Sound.ENTITY_DRAGON_FIREBALL_EXPLODE, 0.8f, 1.0f);
         }
+
+        scoreboard.updateTeamScores();
+
         if (event.hasBingo())
         {
             bingo(event.getParticipant().getTeam());
         }
-        scoreboard.updateTeamScores();
 
         if (event.getParticipant().sessionPlayer().isEmpty())
             return;


### PR DESCRIPTION
Currently if the scoreboard shows after game completes on a lockout game it will show 12 for the winning team when they should have 13.

Moved the update scores call before we end the game so it updates first.