### PR TITLE
Fix stat config usage

### DIFF
--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/gameloop/BingoGame.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/gameloop/BingoGame.java
@@ -68,7 +68,7 @@ public class BingoGame implements GamePhase
         this.settings = settings;
         this.deadPlayers = new HashMap<>();
         this.cardEventManager = new CardEventManager(worldName);
-        if (config.disableStatistics)
+        if (!config.disableStatistics)
             this.statTracker = new StatisticTracker(worldName);
         else
             this.statTracker = null;


### PR DESCRIPTION
Missing negation if config check causes stats to not be tracked