### PR TITLE
Fix removing player issue

### DIFF
--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/player/BingoTeam.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/player/BingoTeam.java
@@ -65,5 +65,6 @@ public class BingoTeam
     {
         members.remove(player);
         team.removeEntry(player.getId().toString());
+        player.sessionPlayer().ifPresent(sessionPlayer -> team.removeEntry(sessionPlayer.getName()));
     }
 }

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/player/BingoTeam.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/player/BingoTeam.java
@@ -12,6 +12,7 @@ import java.util.Set;
 
 public class BingoTeam
 {
+    // Team used to display prefixes next to player display names
     public final Team team;
     public BingoCard card;
     public boolean outOfTheGame = false;
@@ -58,13 +59,12 @@ public class BingoTeam
     public void addMember(BingoParticipant player)
     {
         members.add(player);
-        team.addEntry(player.getId().toString());
+        team.addEntry(player.getDisplayName());
     }
 
     public void removeMember(BingoParticipant player)
     {
         members.remove(player);
-        team.removeEntry(player.getId().toString());
-        player.sessionPlayer().ifPresent(sessionPlayer -> team.removeEntry(sessionPlayer.getName()));
+        team.removeEntry(player.getDisplayName());
     }
 }

--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/player/TeamManager.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/player/TeamManager.java
@@ -174,7 +174,6 @@ public class TeamManager
         if (getBingoParticipant(player) != null)
             removeMemberFromTeam(getBingoParticipant(player));
 
-        bingoTeam.team.addEntry(player.getName());
         new TranslatedMessage(BingoTranslation.JOIN).color(ChatColor.GREEN)
                 .arg(bingoTeam.getColoredName().asLegacyString())
                 .send(player);
@@ -338,7 +337,6 @@ public class TeamManager
         if (existingPlayer != null)
             removeMemberFromTeam(existingPlayer);
 
-        bingoTeam.team.addEntry(playerName);
         VirtualBingoPlayer bingoPlayer = new VirtualBingoPlayer(UUID.randomUUID(), playerName, bingoTeam, session);
         bingoTeam.addMember(bingoPlayer);
         return true;


### PR DESCRIPTION
Team entries seem to be based on player name and not id so removing the player from a team was not working when switching to automatic. 

Currently we add both the id and the player name to entries not sure if there is a reason to add the id but to avoid breaking anything in case there is something I don't understand I simply started removing both when removing a player as well.

Fairly sure we could remove the id from [removing](https://github.com/Steaf23/BingoReloaded/blob/feb26a89ff1bb8bdf50ae7ff86358df4dda241c5/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/player/BingoTeam.java#L67) and [adding](https://github.com/Steaf23/BingoReloaded/blob/feb26a89ff1bb8bdf50ae7ff86358df4dda241c5/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/player/BingoTeam.java#L61) member in BingoTeam.java and make it name based