### PR TITLE
Fix: config.yml is not getting copied on server startup

### DIFF
--- a/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/BingoReloaded.java
+++ b/BingoReloaded/src/main/java/io/github/steaf23/bingoreloaded/BingoReloaded.java
@@ -120,8 +120,6 @@ public class BingoReloaded extends JavaPlugin
         reloadConfig();
         saveDefaultConfig();
 
-        saveConfig();
-
         PLACEHOLDER_API_ENABLED = Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null;
         if (PLACEHOLDER_API_ENABLED) {
             new BingoReloadedPlaceholderExpansion(this).register();

--- a/BingoReloaded/src/main/resources/TODO.txt
+++ b/BingoReloaded/src/main/resources/TODO.txt
@@ -32,7 +32,6 @@
 (3.x) transfer config additions automatically when updating
 (3.x) put automatic team members into random teams instead of the same ones every time (looking at you magenta...)
 
-(BUG) config.yml is not getting copied on server startup, making it use the default values when it should copy the existing config.yml file if available.
 (BUG) Load player data in a bingo world does not teleport the player out
 (BUG) advancement progress is not reset correctly? (MORE INFO NEEDED)
 (BUG) kicking a player from a bingo world displays teleportation failed error even though it worked (related to playerdata)


### PR DESCRIPTION
In BingoReloaded.java:123, code was written to overwrite an empty config after saving the default config.